### PR TITLE
typos in "Green Hills of Tyrol" seconds

### DIFF
--- a/3-4_marches/green_hills_of_tyrol.ly
+++ b/3-4_marches/green_hills_of_tyrol.ly
@@ -46,12 +46,12 @@ musicB = {
   \repeat volta 2 {
     \grg a8. b16 \grip c4 \dblc c8 \gre a
     \grg c8[ \thrwd d] \grg c4 \grip c8 d
-    \dblc c8 d \dble c8. a16 \grg G4
+    \dblc c8 d \dblc c8. a16 \grg G4
     \grd G8 d \dblc c8. a16 \grg a4
     \break
     \grg a8. b16 \grip c4 \dblc c8 \gre a
     \grg c8[ \thrwd d] \grg c4 \grip c8 d
-    \dblc c8 d \dble c8. a16 \grg G4
+    \dblc c8 d \dblc c8. a16 \grg G4
     \grd G8 d \dblc c8. a16 \grg a4
   }
   \break


### PR DESCRIPTION
Hi Sven,

I grabbed a copy of your setting of Green Hills of Tyrol, and found what is probably a typo in the seconds: the commit should be fairly self-explanatory.

Thanks for the great tune collection! I've used a few of them to help seed a new tunes book for our band, though they've invariably needed a few tweaks here and there, since we play slightly different settings.

Regards,
Daniel Dadap, P/C Capitol City Highlanders Pipe Band, Austin, TX
